### PR TITLE
Update Portainer from 2.1 to 2.19.1

### DIFF
--- a/tynor88/PortainerCI.xml
+++ b/tynor88/PortainerCI.xml
@@ -20,7 +20,7 @@
   </Overview>
   <Registry>https://registry.hub.docker.com/r/portainerci/portainer/</Registry>
   <GitHub>https://github.com/portainer/portainer</GitHub>
-  <Repository>portainerci/portainer:2.1</Repository>
+  <Repository>portainerci/portainer:2.19.1</Repository>
   <Support>https://lime-technology.com/forums/topic/69491-support-jj9987-portainer/</Support>
   <BindTime>true</BindTime>
   <Privileged>false</Privileged>


### PR DESCRIPTION
2.1 is from Feb 2, 2021! 🙈 Didn't even realise this app was pegged to that edition